### PR TITLE
Add separate procedure for migration from ZHA to SkyConnect

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -13,8 +13,8 @@ html {
   html {
     --primary-text-color: #e1e1e1;
     --secondary-text-color: #9b9b9b;
-    --primary-background-color: #111111;
-    --secondary-background-color: #202020;
+    --primary-background-color: #202020;
+    --secondary-background-color: #303030;
     --divider-color: rgba(225, 225, 225, 0.12);
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,7 @@ description: Zigbee and Thread USB stick by the creators of Home Assistant
         <h3>Form a new Zigbee network</h3>
       </div>
     </a>
-    <a href="/migrate-zigbee-zha">
+    <a href="/zigbee-migration-selection">
       <div class="layout vertical center">
         <img src="/images/network-migrate.png" width="250" />
         <h3>Migrate an existing <br />Zigbee network</h3>

--- a/src/procedures/migrate-zigbee-zha-only.html
+++ b/src/procedures/migrate-zigbee-zha-only.html
@@ -1,13 +1,11 @@
 ---
 layout: getting-started
 description: Home Assistant SkyConnect
-guideName: Migrate a Zigbee2MQTT network using ZHA
+guideName: Migrate a ZHA network
 
 ---
 <div class="container">
-    <p class="text-center note">Follow this guide if you have a Zigbee2MQTT network running and want to migrate to SkyConnect and ZHA.</p>
+    <p class="text-center note">Follow this guide if you have a Zigbee Home Assistant (ZHA) network running and want to migrate to SkyConnect.</p>
     <p class="text-center note">Note: this procedure only helps migrate basic network settings to your Home Assistant SkyConnect, customizations like device names will be lost and automations will need to be updated. Most powered devices like lightbulbs will be re-discovered over time (you can speed this up by rebooting the device) but your battery-powered devices may need to be re-joined to the network for the migration to complete. There is currently no migration path to migrate all settings and devices.</p>
 </div>
-<p class="text-center note">If you no longer have the old stick, you can <a href="/migrate-zigbee-backup" target="_blank">migrate via z2m backup</a>.</p>
-{% render "proc.include.liquid", proc: procedureMigrateZigbeeZHA %}
 {% render "proc.include.liquid", proc: procedureMigrateZigbeeZHAOnly %}

--- a/src/procedures/migrate-zigbee-zha-only.html
+++ b/src/procedures/migrate-zigbee-zha-only.html
@@ -6,6 +6,5 @@ guideName: Migrate a ZHA network
 ---
 <div class="container">
     <p class="text-center note">Follow this guide if you have a Zigbee Home Assistant (ZHA) network running and want to migrate to SkyConnect.</p>
-    <p class="text-center note">Note: this procedure only helps migrate basic network settings to your Home Assistant SkyConnect, customizations like device names will be lost and automations will need to be updated. Most powered devices like lightbulbs will be re-discovered over time (you can speed this up by rebooting the device) but your battery-powered devices may need to be re-joined to the network for the migration to complete. There is currently no migration path to migrate all settings and devices.</p>
 </div>
 {% render "proc.include.liquid", proc: procedureMigrateZigbeeZHAOnly %}

--- a/src/procedures/procedures.11tydata.yaml
+++ b/src/procedures/procedures.11tydata.yaml
@@ -192,12 +192,16 @@ procedureMigrateZigbeeZHA:
       content: |
         <ul>
           <li>Select <b>Keep radio network settings</b>.</li>
+          <li>You can now start migrating the ZHA network as described below.</li>
         </ul>
+procedureMigrateZigbeeZHAOnly:
+  title: Migrate ZHA network
+  steps:
     - title: Start radio migration
       image: z2m-migrate-zha-02.png
       content: |
         <ol>
-          <li>In the ZHA integration, select <b>Configure</b>.</li>
+          <li>Under <a class="my" href="https://my.home-assistant.io/redirect/integrations/" target="_blank"><b>Settings</b>><b>Devices & Services</b></a>, in the ZHA integration, select <b>Configure</b>.</li>
           <li>Under <b>Network settings</b> add-on, select <b>Migrate Radio</b>.</li>
         </ol>
     - title: Reconfigure ZHA

--- a/src/zigbee-migration-selection.html
+++ b/src/zigbee-migration-selection.html
@@ -1,0 +1,27 @@
+---
+layout: base
+description: Zigbee and Thread USB stick by the creators of Home Assistant
+---
+
+<div class="container">
+  <div class="text-center">
+    <p>
+      
+    </p>
+  </div>
+  <div><h3 class="text-center">Choose your Zigbee migration use case</h3></div>
+  <div class="layout horizontal justified guides">
+    <a href="/migrate-zigbee-zha-only">
+      <div class="layout vertical center">
+        <img src="/images/network-migrate.png"" width="250"/>
+        <h3>Migrate a ZHA network</h3>
+      </div>
+    </a>
+    <a href="/migrate-zigbee-zha">
+      <div class="layout vertical center">
+        <img src="/images/network-migrate.png" width="250"/>
+        <h3>Migrate a Zigbee2MQTT network</h3>
+      </div>
+    </a>
+  </div>
+</div>


### PR DESCRIPTION

- Steps pulled in by reuse from z2m network procedure
- Commit addresses feedback in community forum by chicagoandy.
- Comment was "Where can I find instructions for migrating a ZHA existing network? I could only see docs for migrating mqtt network."