### PR TITLE
Bump sl-web-tools and the corresponding firmwares

### DIFF
--- a/public/flasher.json
+++ b/public/flasher.json
@@ -1,7 +1,11 @@
 {
   "product_name": "Home Assistant SkyConnect",
-  "bootloader_baudrate": 115200,
-  "application_baudrate": 115200,
+  "baudrates": {
+    "bootloader": [115200],
+    "cpc": [460800, 115200, 230400],
+    "ezsp": [115200],
+    "spinel": [460800]
+  },
   "usb_filters": [
     {
       "pid": 60000,
@@ -11,15 +15,21 @@
   "firmwares": [
     {
       "name": "Zigbee (EZSP)",
-      "url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/EmberZNet/beta/NabuCasa_SkyConnect_EZSP_v7.1.4.0_ncp-uart-hw_115200.gbl",
+      "url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/EmberZNet/beta/NabuCasa_SkyConnect_EZSP_v7.2.2.0_ncp-uart-hw_115200.gbl",
       "type": "ncp-uart-hw",
-      "version": "7.1.4.0"
+      "version": "7.2.2.0"
     },
     {
       "name": "Multi-PAN (RCP)",
-      "url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/RCPMultiPAN/NabuCasa_SkyConnect_RCP_v4.1.4_rcp-uart-hw-802154_115200.gbl",
+      "url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/RCPMultiPAN/beta/NabuCasa_SkyConnect_RCP_v4.2.2_rcp-uart-hw-802154_460800.gbl",
       "type": "rcp-uart-802154",
-      "version": "4.1.4"
+      "version": "4.2.2"
+    },
+    {
+      "name": "OpenThread",
+      "url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/OpenThreadRCP/NabuCasa_SkyConnect_OpenThread_RCP_v2.2.2.0_ot-rcp_hw_460800.gbl",
+      "type": "ot-rcp",
+      "version": "2.2.2.0"
     }
   ],
   "allow_custom_firmware_upload": true

--- a/src/firmware-update.html
+++ b/src/firmware-update.html
@@ -24,5 +24,5 @@ description: Zigbee and Thread USB stick by the creators of Home Assistant
 </div>
 <script
   type="module"
-  src="https://unpkg.com/@nabucasa/sl-web-tools@0.9.4/dist/web/nabucasa-zigbee-flasher.js?module"
+  src="https://unpkg.com/@nabucasa/sl-web-tools@0.10.0/dist/web/nabucasa-zigbee-flasher.js?module"
 ></script>


### PR DESCRIPTION
This makes OpenThread public but more importantly, allows for re-flashing from higher baudrate CPC firmware.