### PR TITLE
Update redirect link

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,2 @@
 /ce             /resources/SkyConnect_DoC_EU_CE.pdf
-/multiprotocol-channel-missmatch /about-multiprotocol/
+/multiprotocol-channel-missmatch /about-multiprotocol/#resolve-channel-conflict


### PR DESCRIPTION
- The link still pointed to the disable multiprotocol procedure, 
- as at the time there was no topic About multiprotocol issues.