### PR TITLE
Fix a broken link

### DIFF
--- a/src/faq.html
+++ b/src/faq.html
@@ -114,7 +114,7 @@ faqs:
       <p>
         Note: The multiprotocol feature is still experimental.
       </p>
-      <p>OTBR and ZHA on separate channels can cause an unreliable network connection. To resolve this issue, you can try resetting the Thread network or use two separate wireless chips, one for ZHA and one for Thread. See <a href="/guides/about-multiprotocol/#resolve-channel-conflict" target="_blank">About
+      <p>OTBR and ZHA on separate channels can cause an unreliable network connection. To resolve this issue, you can try resetting the Thread network or use two separate wireless chips, one for ZHA and one for Thread. See <a href="/about-multiprotocol/#resolve-channel-conflict" target="_blank">About
         multiprotocol support - resolve channel conflict</a>.</p>
       <p>Note: The OpenThread Border Router add-on used to setup a Thread-only network on a wireless chip is still experimental.</p>
 ---


### PR DESCRIPTION
The link from (the last item of) the FAQ to the multiprotocol issues documentation was broken. This PR is supposed to fix it