### PR TITLE
convert markdown links to html in index page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -33,6 +33,6 @@ description: Zigbee and Thread USB stick by the creators of Home Assistant
     <div>
       <h3>Thread and Matter</h3>
       <p>SkyConnect comes with experimental support to power Thread (used for some Matter devices) and
-        Zigbee networks at the same time. Before [enabling multiprotocol support](/procedures/enable-multiprotocol/), check the section about [multiprotocol issues](about-multiprotocol).</p>
+        Zigbee networks at the same time. Before <a href="/procedures/enable-multiprotocol/">enabling multiprotocol support</a>, check the section about <a href="/about-multiprotocol/">multiprotocol issues</a>.</p>
     </div>
 </div>


### PR DESCRIPTION
Noticed these two broken links on the website while setting up my Skyconnect, so duly submitted.