### PR TITLE
Rename contact to support

### DIFF
--- a/src/_includes/base.liquid
+++ b/src/_includes/base.liquid
@@ -81,7 +81,7 @@ menu:
       <div class="footer">
         <div>
           Home&nbsp;Assistant SkyConnect &nbsp; – &nbsp;
-          <a href="mailto:hello@home-assistant.io">Contact</a>
+          <a href="mailto:hello@home-assistant.io">Support</a>
           &nbsp; – &nbsp;
           <a href="https://www.github.com/home-assistant" target="_blank">GitHub</a>
           &nbsp; – &nbsp;


### PR DESCRIPTION
- On the main documentation page, there is a Contact (no support) link
  - but on this page, Contact is used for support.
  - rename it to improve consistency.