### PR TITLE
Fix connection issue with web flasher

### DIFF
--- a/public/flasher.json
+++ b/public/flasher.json
@@ -15,21 +15,21 @@
   "firmwares": [
     {
       "name": "Zigbee (EZSP)",
-      "url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/EmberZNet/beta/NabuCasa_SkyConnect_EZSP_v7.2.2.0_ncp-uart-hw_115200.gbl",
+      "url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/EmberZNet/beta/NabuCasa_SkyConnect_EZSP_v7.3.2.0_ncp-uart-hw_115200.gbl",
       "type": "ncp-uart-hw",
-      "version": "7.2.2.0"
+      "version": "7.3.2.0"
     },
     {
       "name": "Multi-PAN (RCP)",
-      "url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/RCPMultiPAN/beta/NabuCasa_SkyConnect_RCP_v4.2.2_rcp-uart-hw-802154_460800.gbl",
+      "url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/RCPMultiPAN/beta/NabuCasa_SkyConnect_RCP_v4.3.2_rcp-uart-hw-802154_460800.gbl",
       "type": "rcp-uart-802154",
-      "version": "4.2.2"
+      "version": "4.3.2"
     },
     {
       "name": "OpenThread",
-      "url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/OpenThreadRCP/NabuCasa_SkyConnect_OpenThread_RCP_v2.2.2.0_ot-rcp_hw_460800.gbl",
+      "url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/OpenThreadRCP/NabuCasa_SkyConnect_OpenThread_RCP_v2.3.2.0_ot-rcp_hw_460800.gbl",
       "type": "ot-rcp",
-      "version": "2.2.2.0"
+      "version": "2.3.2.0"
     }
   ],
   "allow_custom_firmware_upload": true

--- a/src/firmware-update.html
+++ b/src/firmware-update.html
@@ -24,5 +24,5 @@ description: Zigbee and Thread USB stick by the creators of Home Assistant
 </div>
 <script
   type="module"
-  src="https://unpkg.com/@nabucasa/sl-web-tools@0.10.0/dist/web/nabucasa-zigbee-flasher.js?module"
+  src="https://unpkg.com/@nabucasa/sl-web-tools@0.10.1/dist/web/nabucasa-zigbee-flasher.js?module"
 ></script>


### PR DESCRIPTION
The web flasher is currently broken due to a dependency issue with sl-web-tools (https://github.com/NabuCasa/sl-web-tools/pull/12), fixed by the most recent release. I've also bumped the firmware files to the latest version.

Fixes #92.